### PR TITLE
Fix Robolectric name

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ By Siddhant Mehta (Android Developer)
 - Concurrency   :   Coroutines
 - DI            :   Hilt
 - UI            :   View Binding
-- Testing       :   JUnit + Espresso + RoboElectric + Mockito
+- Testing       :   JUnit + Espresso + Robolectric + Mockito
 - CI/CD         :   Github-Actions
 
 


### PR DESCRIPTION
The name of the library was wrong in the Readme: `RoboElectric` -> `Robolectric`.

**Note:** it should also be changed in the project description and tags:
<img width="309" alt="Screenshot 2025-04-08 at 09 20 33" src="https://github.com/user-attachments/assets/51c00a63-5c15-4db5-af8d-29607ec967b1" />
